### PR TITLE
Detour methods that call GetRandomBuildingInfo

### DIFF
--- a/BuildingThemes/BuildingThemesMod.cs
+++ b/BuildingThemes/BuildingThemesMod.cs
@@ -8,6 +8,7 @@ using System.Text;
 using UnityEngine;
 using System.Reflection;
 using System.Threading;
+using ColossalFramework.Math;
 
 namespace BuildingThemes
 {
@@ -64,7 +65,10 @@ namespace BuildingThemes
     {
         public string Name
         {
-            get { return "Building Themes"; }
+            get
+            {
+                return "Building Themes";
+            }
         }
 
         public string Description
@@ -77,6 +81,7 @@ namespace BuildingThemes
         public override void OnCreated(ILoading loading)
         {
             base.OnCreated(loading);
+            DetoursHolder.InitTable();
             ReplaceBuildingManager();
 
             var methodInfo = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);

--- a/BuildingThemes/BuildingThemesMod.cs
+++ b/BuildingThemes/BuildingThemesMod.cs
@@ -24,6 +24,28 @@ namespace BuildingThemes
 
         private UIButton tab;
 
+        public override void OnCreated(ILoading loading)
+        {
+            base.OnCreated(loading);
+            ReplaceBuildingManager();
+
+            var methodInfo1 = typeof(PrivateBuildingAI).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
+            DetoursHolder.privateBuidingAiSimulationStepState = RedirectionHelper.RedirectCalls(
+                methodInfo1,
+                typeof(DetoursHolder).GetMethod("PrivateBuildingAiSimulationStep", BindingFlags.Public | BindingFlags.Instance)
+                );
+            var methodInfo2 = typeof(PrivateBuildingAI).GetMethod("GetUpgradeInfo", BindingFlags.Public | BindingFlags.Instance);
+            DetoursHolder.privateBuidingAiGetUpgradeInfoState = RedirectionHelper.RedirectCalls(
+                methodInfo2,
+                typeof(DetoursHolder).GetMethod("PrivateBuildingAiGetUpgradeInfo", BindingFlags.Public | BindingFlags.Instance)
+                );
+            var methodInfo3 = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
+            DetoursHolder.zoneBlockSimulationStepState = RedirectionHelper.RedirectCalls(
+                methodInfo3,
+                typeof(DetoursHolder).GetMethod("ZoneBlockSimulationStep", BindingFlags.Public | BindingFlags.Instance)
+                );
+        }
+
         public override void OnLevelLoaded(LoadMode mode) 
         {
             // Is it an actual game ?
@@ -33,9 +55,6 @@ namespace BuildingThemes
 
             // Hook into policies GUI
             ToolsModifierControl.policiesPanel.component.eventVisibilityChanged += OnPoliciesPanelVisibilityChanged;
-
-            // Replace BuildingManager. Credits to Traffic++ developers ;)
-            ReplaceBuildingManager();
         }
 
         public override void OnLevelUnloading()

--- a/BuildingThemes/BuildingThemesMod.cs
+++ b/BuildingThemes/BuildingThemesMod.cs
@@ -24,7 +24,7 @@ namespace BuildingThemes
             BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
             UnityEngine.Debug.LogFormat("Building Themes: OnCalculateResidentialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
-            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            DetoursHolder.position = building.m_position;
             return levelUp;
         }
 
@@ -34,7 +34,7 @@ namespace BuildingThemes
             BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
             UnityEngine.Debug.LogFormat("Building Themes: OnCalculateOfficeLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
-            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            DetoursHolder.position = building.m_position;
             return levelUp;
         }
 
@@ -44,7 +44,7 @@ namespace BuildingThemes
            BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
             UnityEngine.Debug.LogFormat("Building Themes: OnCalculateCommercialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
-            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            DetoursHolder.position = building.m_position;
             return levelUp;
         }
 
@@ -54,7 +54,7 @@ namespace BuildingThemes
             BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
             UnityEngine.Debug.LogFormat("Building Themes: OnCalculateIndustrialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
-            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            DetoursHolder.position = building.m_position;
             return levelUp;
         }
     }

--- a/BuildingThemes/BuildingThemesMod.cs
+++ b/BuildingThemes/BuildingThemesMod.cs
@@ -7,6 +7,7 @@ using ColossalFramework.Plugins;
 using System.Text;
 using UnityEngine;
 using System.Reflection;
+using System.Resources;
 using System.Threading;
 using ColossalFramework.Math;
 
@@ -114,6 +115,13 @@ namespace BuildingThemes
             DetoursHolder.zoneBlockSimulationStepState = RedirectionHelper.PatchJumpTo(
                 DetoursHolder.zoneBlockSimulationStepPtr,
                 DetoursHolder.zoneBlockSimulationStepDetourPtr
+                );
+            DetoursHolder.resourceManagerAddResource = typeof(ImmaterialResourceManager).GetMethod("AddResource", new[] { typeof(ImmaterialResourceManager.Resource), typeof(int), typeof(Vector3), typeof(float) });
+            DetoursHolder.resourceManagerAddResourcePtr = DetoursHolder.resourceManagerAddResource.MethodHandle.GetFunctionPointer();
+            DetoursHolder.resourceManagerAddResourceDetourPtr = typeof(DetoursHolder).GetMethod("ImmaterialResourceManagerAddResource").MethodHandle.GetFunctionPointer();
+            DetoursHolder.resourceManagerAddResourceState = RedirectionHelper.PatchJumpTo(
+                DetoursHolder.resourceManagerAddResourcePtr,
+                DetoursHolder.resourceManagerAddResourceDetourPtr
                 );
         }
 

--- a/BuildingThemes/BuildingThemesMod.cs
+++ b/BuildingThemes/BuildingThemesMod.cs
@@ -23,7 +23,10 @@ namespace BuildingThemes
         {
             BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
-            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateResidentialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            if (BuildingThemesMod.isDebug)
+            {
+                UnityEngine.Debug.LogFormat("Building Themes: OnCalculateResidentialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            }
             DetoursHolder.position = building.m_position;
             return levelUp;
         }
@@ -33,7 +36,13 @@ namespace BuildingThemes
         {
             BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
-            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateOfficeLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            if (BuildingThemesMod.isDebug)
+            {
+
+                UnityEngine.Debug.LogFormat(
+                    "Building Themes: OnCalculateOfficeLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}",
+                    buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            }
             DetoursHolder.position = building.m_position;
             return levelUp;
         }
@@ -43,7 +52,13 @@ namespace BuildingThemes
         {
            BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
-            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateCommercialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            if (BuildingThemesMod.isDebug)
+            {
+
+                UnityEngine.Debug.LogFormat(
+                    "Building Themes: OnCalculateCommercialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}",
+                    buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            }
             DetoursHolder.position = building.m_position;
             return levelUp;
         }
@@ -53,7 +68,13 @@ namespace BuildingThemes
         {
             BuildingManager buildingManager = Singleton<BuildingManager>.instance;
             Building building = buildingManager.m_buildings.m_buffer[buildingID];
-            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateIndustrialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            if (BuildingThemesMod.isDebug)
+            {
+
+                UnityEngine.Debug.LogFormat(
+                    "Building Themes: OnCalculateIndustrialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}",
+                    buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            }
             DetoursHolder.position = building.m_position;
             return levelUp;
         }
@@ -63,6 +84,9 @@ namespace BuildingThemes
 
     public class BuildingThemesMod : LoadingExtensionBase, IUserMod
     {
+
+        public static bool isDebug = false;
+
         public string Name
         {
             get
@@ -84,10 +108,12 @@ namespace BuildingThemes
             DetoursHolder.InitTable();
             ReplaceBuildingManager();
 
-            var methodInfo = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
-            DetoursHolder.zoneBlockSimulationStepState = RedirectionHelper.RedirectCalls(
-                methodInfo,
-                typeof(DetoursHolder).GetMethod("ZoneBlockSimulationStep", BindingFlags.Public | BindingFlags.Instance)
+            DetoursHolder.zoneBlockSimulationStep = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
+            DetoursHolder.zoneBlockSimulationStepPtr = DetoursHolder.zoneBlockSimulationStep.MethodHandle.GetFunctionPointer();
+            DetoursHolder.zoneBlockSimulationStepDetourPtr = typeof(DetoursHolder).GetMethod("ZoneBlockSimulationStep", BindingFlags.Public | BindingFlags.Instance).MethodHandle.GetFunctionPointer();
+            DetoursHolder.zoneBlockSimulationStepState = RedirectionHelper.PatchJumpTo(
+                DetoursHolder.zoneBlockSimulationStepPtr,
+                DetoursHolder.zoneBlockSimulationStepDetourPtr
                 );
         }
 

--- a/BuildingThemes/BuildingThemesMod.cs
+++ b/BuildingThemes/BuildingThemesMod.cs
@@ -7,9 +7,59 @@ using ColossalFramework.Plugins;
 using System.Text;
 using UnityEngine;
 using System.Reflection;
+using System.Threading;
 
 namespace BuildingThemes
 {
+
+
+    public class LevelUpExtension : LevelUpExtensionBase
+    {
+
+        public override ResidentialLevelUp OnCalculateResidentialLevelUp(ResidentialLevelUp levelUp,
+            int averageEducation, int landValue, ushort buildingID, Service service, SubService subService,
+            Level currentLevel)
+        {
+            BuildingManager buildingManager = Singleton<BuildingManager>.instance;
+            Building building = buildingManager.m_buildings.m_buffer[buildingID];
+            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateResidentialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            return levelUp;
+        }
+
+        public override OfficeLevelUp OnCalculateOfficeLevelUp(OfficeLevelUp levelUp, int averageEducation,
+            int serviceScore, ushort buildingID, Service service, SubService subService, Level currentLevel)
+        {
+            BuildingManager buildingManager = Singleton<BuildingManager>.instance;
+            Building building = buildingManager.m_buildings.m_buffer[buildingID];
+            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateOfficeLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            return levelUp;
+        }
+
+        public override CommercialLevelUp OnCalculateCommercialLevelUp(CommercialLevelUp levelUp, int averageWealth,
+            int landValue, ushort buildingID, Service service, SubService subService, Level currentLevel)
+        {
+           BuildingManager buildingManager = Singleton<BuildingManager>.instance;
+            Building building = buildingManager.m_buildings.m_buffer[buildingID];
+            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateCommercialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            return levelUp;
+        }
+
+        public override IndustrialLevelUp OnCalculateIndustrialLevelUp(IndustrialLevelUp levelUp, int averageEducation,
+            int serviceScore, ushort buildingID, Service service, SubService subService, Level currentLevel)
+        {
+            BuildingManager buildingManager = Singleton<BuildingManager>.instance;
+            Building building = buildingManager.m_buildings.m_buffer[buildingID];
+            UnityEngine.Debug.LogFormat("Building Themes: OnCalculateIndustrialLevelUp. buildingID: {0}, target level: {1}, position: {2}. current thread: {3}", buildingID, levelUp.targetLevel, building.m_position, Thread.CurrentThread.ManagedThreadId);
+            DetoursHolder.position = DetoursHolder.Position.Build(building.m_position);
+            return levelUp;
+        }
+    }
+
+
+
     public class BuildingThemesMod : LoadingExtensionBase, IUserMod
     {
         public string Name
@@ -29,19 +79,9 @@ namespace BuildingThemes
             base.OnCreated(loading);
             ReplaceBuildingManager();
 
-            var methodInfo1 = typeof(PrivateBuildingAI).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
-            DetoursHolder.privateBuidingAiSimulationStepState = RedirectionHelper.RedirectCalls(
-                methodInfo1,
-                typeof(DetoursHolder).GetMethod("PrivateBuildingAiSimulationStep", BindingFlags.Public | BindingFlags.Instance)
-                );
-            var methodInfo2 = typeof(PrivateBuildingAI).GetMethod("GetUpgradeInfo", BindingFlags.Public | BindingFlags.Instance);
-            DetoursHolder.privateBuidingAiGetUpgradeInfoState = RedirectionHelper.RedirectCalls(
-                methodInfo2,
-                typeof(DetoursHolder).GetMethod("PrivateBuildingAiGetUpgradeInfo", BindingFlags.Public | BindingFlags.Instance)
-                );
-            var methodInfo3 = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
+            var methodInfo = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
             DetoursHolder.zoneBlockSimulationStepState = RedirectionHelper.RedirectCalls(
-                methodInfo3,
+                methodInfo,
                 typeof(DetoursHolder).GetMethod("ZoneBlockSimulationStep", BindingFlags.Public | BindingFlags.Instance)
                 );
         }

--- a/BuildingThemes/DetoursHolder.cs
+++ b/BuildingThemes/DetoursHolder.cs
@@ -76,12 +76,22 @@ namespace BuildingThemes
 
             FastList<ushort> fastList = areaBuildings[(int)getAreaIndex.Invoke(null, new object[] { service, subService, level, width, length, zoningMode })];
             if (fastList == null)
+            {
+                UnityEngine.Debug.LogFormat("Building Themes: Fast list is null. Return null, current thread: {0}",
+                     Thread.CurrentThread.ManagedThreadId);
                 return (BuildingInfo)null;
+            }
+
             if (fastList.m_size == 0)
+            {
+                UnityEngine.Debug.LogFormat("Building Themes: Fast list is empty. Return null, current thread: {0}", Thread.CurrentThread.ManagedThreadId);
                 return (BuildingInfo)null;
+            }
+
             if (r.seed == Singleton<SimulationManager>.instance.m_randomizer.seed)
             {
-                UnityEngine.Debug.Log("Building Themes: Getting position from static variable...");
+                UnityEngine.Debug.LogFormat("Building Themes: Getting position from static variable, current thread: {0}",
+                    Thread.CurrentThread.ManagedThreadId);
                 do
                 {
                 } while (!Monitor.TryEnter(Lock, SimulationManager.SYNCHRONIZE_TIMEOUT));
@@ -109,13 +119,13 @@ namespace BuildingThemes
             else
             {
                 UnityEngine.Debug.LogFormat(
-                    "Building Themes: Getting position from seed {0}...", r.seed);
+                    "Building Themes: Getting position from seed {0}. current thread: {0}, threadId: {1}", r.seed, Thread.CurrentThread.ManagedThreadId);
                 var buildingId = seedTable[r.seed];
                 var building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingId];
                 var buildingPosition = Position.Build(building.m_position);
                 UnityEngine.Debug.LogFormat(
                         "Building Themes: Getting position from seed {0}. building: {1}, buildingId: {2}, position: {3}, threadId: {4}",
-                        r.seed, building.Info.name, buildingId, buildingPosition, 
+                        r.seed, building.Info.name, buildingId, buildingPosition.getValue(), 
                         Thread.CurrentThread.ManagedThreadId);
                 FilterList(buildingPosition, ref fastList);
             }

--- a/BuildingThemes/DetoursHolder.cs
+++ b/BuildingThemes/DetoursHolder.cs
@@ -14,13 +14,14 @@ namespace BuildingThemes
     class DetoursHolder
     {
 
-        private static Dictionary<ulong, ushort> seedTable = new Dictionary<ulong, ushort>(); 
+        private static Dictionary<ulong, ushort> seedTable = new Dictionary<ulong, ushort>();
 
         public static void InitTable()
         {
 
-            for (ushort _seed = 0; _seed <= 65534; ++_seed) { 
-                var seed = (ulong) (6364136223846793005L*(long) _seed + 1442695040888963407L);
+            for (ushort _seed = 0; _seed <= 65534; ++_seed)
+            {
+                var seed = (ulong)(6364136223846793005L * (long)_seed + 1442695040888963407L);
                 seedTable.Add(seed, _seed);
             }
         }
@@ -29,7 +30,11 @@ namespace BuildingThemes
         public static Vector3 position;
 
         public static RedirectCallsState zoneBlockSimulationStepState;
-
+        public static MethodInfo zoneBlockSimulationStep;
+        public static IntPtr zoneBlockSimulationStepPtr;
+        public static IntPtr zoneBlockSimulationStepDetourPtr;
+        private static MethodInfo refreshAreaBuidlings;
+        private static MethodInfo getAreaIndex;
 
         //this is detoured version of BuildingManger#GetRandomBuildingInfo method. Note, that it's an instance method. It's better because this way all registers will be expected to have the same values
         //as in original methods
@@ -38,59 +43,89 @@ namespace BuildingThemes
 
             var isRandomizerSimulatorManagers = r.seed == Singleton<SimulationManager>.instance.m_randomizer.seed; //I do it here in case if randomizer methodos mell be called later
             var randimizerSeed = r.seed; //if they are called seed will change
-            UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo was called. seed: {0} (singleton seed: {1}). service: {2}, subService: {3}," +
-                "level: {4}, width: {5}, length: {6}, zoningMode: {7}, current thread: {8}\nStack trace: {9}", r.seed, Singleton<SimulationManager>.instance.m_randomizer.seed,
-                service, subService, level, width, length, zoningMode,
-                                        Thread.CurrentThread.ManagedThreadId, System.Environment.StackTrace);
+            if (BuildingThemesMod.isDebug)
+            {
+                UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo was called. seed: {0} (singleton seed: {1}). service: {2}, subService: {3}," +
+                    "level: {4}, width: {5}, length: {6}, zoningMode: {7}, current thread: {8}\nStack trace: {9}", r.seed, Singleton<SimulationManager>.instance.m_randomizer.seed,
+                    service, subService, level, width, length, zoningMode,
+                                            Thread.CurrentThread.ManagedThreadId, System.Environment.StackTrace);
+            }
             //this part is the same as in original method
-            //I love this hack :) This is how I get this reference - and save it to a variable
-            var buildingManager = (BuildingManager)Convert.ChangeType(this, typeof(BuildingManager));
-            var refreshAreaBuidlings = typeof(BuildingManager).GetMethod("RefreshAreaBuildings", BindingFlags.NonPublic | BindingFlags.Instance);
+            var buildingManager = Singleton<BuildingManager>.instance;
+            if (refreshAreaBuidlings == null)
+            {
+                refreshAreaBuidlings = typeof(BuildingManager).GetMethod("RefreshAreaBuildings", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
             refreshAreaBuidlings.Invoke(buildingManager, new object[] { });
-            var areaBuildings = (FastList<ushort>[])GetInstanceField(typeof(BuildingManager), buildingManager,
-                "m_areaBuildings");
-            var getAreaIndex = typeof(BuildingManager).GetMethod("GetAreaIndex", BindingFlags.NonPublic | BindingFlags.Static);
-
+            var areaBuildings = (FastList<ushort>[])GetInstanceField(typeof(BuildingManager), buildingManager, "m_areaBuildings");
+            if (getAreaIndex == null)
+            {
+                getAreaIndex = typeof(BuildingManager).GetMethod("GetAreaIndex", BindingFlags.NonPublic | BindingFlags.Static);
+            }
             FastList<ushort> fastList = areaBuildings[(int)getAreaIndex.Invoke(null, new object[] { service, subService, level, width, length, zoningMode })];
             if (fastList == null)
             {
-                UnityEngine.Debug.LogFormat("Building Themes: Fast list is null. Return null, current thread: {0}",
-                     Thread.CurrentThread.ManagedThreadId);
+                if (BuildingThemesMod.isDebug)
+                {
+                    UnityEngine.Debug.LogFormat("Building Themes: Fast list is null. Return null, current thread: {0}",
+                        Thread.CurrentThread.ManagedThreadId);
+                }
                 return (BuildingInfo)null;
             }
 
             if (fastList.m_size == 0)
             {
-                UnityEngine.Debug.LogFormat("Building Themes: Fast list is empty. Return null, current thread: {0}", Thread.CurrentThread.ManagedThreadId);
+                if (BuildingThemesMod.isDebug)
+                {
+                    UnityEngine.Debug.LogFormat(
+                        "Building Themes: Fast list is empty. Return null, current thread: {0}",
+                        Thread.CurrentThread.ManagedThreadId);
+                }
                 return (BuildingInfo)null;
             }
 
             if (isRandomizerSimulatorManagers)
             {
-                UnityEngine.Debug.LogFormat("Building Themes: Getting position from static variable. position: {0}, current thread: {1}",
-                    position, Thread.CurrentThread.ManagedThreadId);
-                    FilterList(position, ref fastList);
+                if (BuildingThemesMod.isDebug)
+                {
+                    UnityEngine.Debug.LogFormat(
+                        "Building Themes: Getting position from static variable. position: {0}, current thread: {1}",
+                        position, Thread.CurrentThread.ManagedThreadId);
+                }
+                FilterList(position, ref fastList);
             }
             else
             {
-                UnityEngine.Debug.LogFormat(
-                    "Building Themes: Getting position from seed {0}... current thread: {1}", randimizerSeed, Thread.CurrentThread.ManagedThreadId);
+                if (BuildingThemesMod.isDebug)
+                {
+                    UnityEngine.Debug.LogFormat(
+                        "Building Themes: Getting position from seed {0}... current thread: {1}", randimizerSeed,
+                        Thread.CurrentThread.ManagedThreadId);
+                }
                 var buildingId = seedTable[randimizerSeed];
                 var building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingId];
                 var buildingPosition = building.m_position;
-                UnityEngine.Debug.LogFormat(
+                if (BuildingThemesMod.isDebug)
+                {
+                    UnityEngine.Debug.LogFormat(
                         "Building Themes: Getting position from seed {0}. building: {1}, buildingId: {2}, position: {3}, threadId: {4}",
-                        randimizerSeed, building.Info.name, buildingId, buildingPosition, 
+                        randimizerSeed, building.Info.name, buildingId, buildingPosition,
                         Thread.CurrentThread.ManagedThreadId);
+                }
                 FilterList(buildingPosition, ref fastList);
             }
             if (fastList.m_size == 0)
             {
-                UnityEngine.Debug.LogFormat("Building Themes: Filtered list is empty. Return null, current thread: {0}", Thread.CurrentThread.ManagedThreadId);
+                if (BuildingThemesMod.isDebug)
+                {
+                    UnityEngine.Debug.LogFormat(
+                        "Building Themes: Filtered list is empty. Return null, current thread: {0}",
+                        Thread.CurrentThread.ManagedThreadId);
+                }
                 return (BuildingInfo)null;
             }
             int index = r.Int32((uint)fastList.m_size);
-            var buildingInfo = PrefabCollection<BuildingInfo>.GetPrefab((uint) fastList.m_buffer[index]);
+            var buildingInfo = PrefabCollection<BuildingInfo>.GetPrefab((uint)fastList.m_buffer[index]);
             return buildingInfo;
         }
 
@@ -98,22 +133,26 @@ namespace BuildingThemes
         {
             ushort districtIdx = Singleton<DistrictManager>.instance.GetDistrict(position);
             //districtIdx==0 probably means 'outside of any district'
-            UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo. districtIdx: {0};current thread: {1}",
-                districtIdx, Thread.CurrentThread.ManagedThreadId);
+            if (BuildingThemesMod.isDebug)
+            {
+                UnityEngine.Debug.LogFormat(
+                    "Building Themes: Detoured GetRandomBuildingInfo. districtIdx: {0};current thread: {1}",
+                    districtIdx, Thread.CurrentThread.ManagedThreadId);
+            }
             //District district = Singleton<DistrictManager>.instance.m_districts.m_buffer[districtIdx];
             //TODO(earalov): here fastList variable should be filtered. All buildings that  don't belong to the district should be removed from this list.
-            
-            
+
             //this is stub implementation
             FastList<ushort> newList = new FastList<ushort>();
-            for (int i=0;i<list.m_size;i++)
+            for (int i = 0; i < list.m_size; i++)
             {
                 var name = PrefabCollection<BuildingInfo>.GetPrefab(list.m_buffer[i]).name;
-                if (name.Contains("lock") && districtIdx == 0)
+                var isEuropean = (name.Contains("lock") || name.Contains("EU"));
+                if (isEuropean && districtIdx == 0)
                 {
                     continue;
                 }
-                if (!name.Contains("lock") && districtIdx != 0)
+                if (!isEuropean && districtIdx != 0)
                 {
                     continue;
                 }
@@ -126,18 +165,16 @@ namespace BuildingThemes
         public void ZoneBlockSimulationStep(ushort blockID)
         {
             var zoneBlock = Singleton<ZoneManager>.instance.m_blocks.m_buffer[blockID];
-            UnityEngine.Debug.LogFormat("Building Themes: Detoured ZoneBlock.SimulationStep was called. blockID: {0}, position: {1}. current thread: {2}", blockID, zoneBlock.m_position, Thread.CurrentThread.ManagedThreadId);
+            if (BuildingThemesMod.isDebug)
+            {
+                UnityEngine.Debug.LogFormat(
+                    "Building Themes: Detoured ZoneBlock.SimulationStep was called. blockID: {0}, position: {1}. current thread: {2}",
+                    blockID, zoneBlock.m_position, Thread.CurrentThread.ManagedThreadId);
+            }
             position = zoneBlock.m_position;
-            var methodInfo = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
-            RedirectionHelper.RevertRedirect(
-                methodInfo,
-                zoneBlockSimulationStepState
-                );
-            methodInfo.Invoke(zoneBlock, new object[] { blockID });
-            RedirectionHelper.RedirectCalls(
-                methodInfo,
-                typeof(DetoursHolder).GetMethod("ZoneBlockSimulationStep", BindingFlags.Public | BindingFlags.Instance)
-                );
+            RedirectionHelper.RevertJumpTo(zoneBlockSimulationStepPtr, zoneBlockSimulationStepState);
+            zoneBlockSimulationStep.Invoke(zoneBlock, new object[] { blockID });
+            RedirectionHelper.PatchJumpTo(zoneBlockSimulationStepPtr, zoneBlockSimulationStepDetourPtr);
 
         }
 

--- a/BuildingThemes/DetoursHolder.cs
+++ b/BuildingThemes/DetoursHolder.cs
@@ -57,14 +57,10 @@ namespace BuildingThemes
         //as in original methods
         public BuildingInfo GetRandomBuildingInfo(ref Randomizer r, ItemClass.Service service, ItemClass.SubService subService, ItemClass.Level level, int width, int length, BuildingInfo.ZoningMode zoningMode)
         {
-            UnityEngine.Debug.Log("Building Themes: Detoured GetRandomBuildingInfo was called. Stack trace: " + System.Environment.StackTrace);
-
-            var positionStr = position != null ? position.getValue().ToString() : "null";
-
-            UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo. position: {0}. service: {1}, subService: {2}," +
-                "level: {3}, width: {4}, length: {5}, zoningMode: {6}, current thread: {7}", positionStr, service, subService,
-                                        level, width, length, zoningMode,
-                                        Thread.CurrentThread.ManagedThreadId);
+            UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo was called. seed: {0} (singleton seed: {1}). service: {2}, subService: {3}," +
+                "level: {4}, width: {5}, length: {6}, zoningMode: {7}, current thread: {8}\nStack trace: {9}", r.seed, Singleton<SimulationManager>.instance.m_randomizer.seed,
+                service, subService, level, width, length, zoningMode,
+                                        Thread.CurrentThread.ManagedThreadId, System.Environment.StackTrace);
             //this part is the same as in original method
             //I love this hack :) This is how I get this reference - and save it to a variable
             var buildingManager = (BuildingManager)Convert.ChangeType(this, typeof(BuildingManager));
@@ -90,14 +86,15 @@ namespace BuildingThemes
 
             if (r.seed == Singleton<SimulationManager>.instance.m_randomizer.seed)
             {
-                UnityEngine.Debug.LogFormat("Building Themes: Getting position from static variable, current thread: {0}",
-                    Thread.CurrentThread.ManagedThreadId);
+
                 do
                 {
                 } while (!Monitor.TryEnter(Lock, SimulationManager.SYNCHRONIZE_TIMEOUT));
                 try
                 {
-
+                    var positionStr = position != null ? position.getValue().ToString() : "null";
+                    UnityEngine.Debug.LogFormat("Building Themes: Getting position from static variable. position: {0}, current thread: {1}",
+                        positionStr, Thread.CurrentThread.ManagedThreadId);
                     if (position != null)
                     {
                         FilterList(position, ref fastList);
@@ -119,7 +116,7 @@ namespace BuildingThemes
             else
             {
                 UnityEngine.Debug.LogFormat(
-                    "Building Themes: Getting position from seed {0}. current thread: {0}, threadId: {1}", r.seed, Thread.CurrentThread.ManagedThreadId);
+                    "Building Themes: Getting position from seed {0}... current thread: {1}", r.seed, Thread.CurrentThread.ManagedThreadId);
                 var buildingId = seedTable[r.seed];
                 var building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingId];
                 var buildingPosition = Position.Build(building.m_position);

--- a/BuildingThemes/DetoursHolder.cs
+++ b/BuildingThemes/DetoursHolder.cs
@@ -126,9 +126,14 @@ namespace BuildingThemes
                         Thread.CurrentThread.ManagedThreadId);
                 FilterList(buildingPosition, ref fastList);
             }
-
+            if (fastList.m_size == 0)
+            {
+                UnityEngine.Debug.LogFormat("Building Themes: Filtered list is empty. Return null, current thread: {0}", Thread.CurrentThread.ManagedThreadId);
+                return (BuildingInfo)null;
+            }
             int index = r.Int32((uint)fastList.m_size);
-            return PrefabCollection<BuildingInfo>.GetPrefab((uint)fastList.m_buffer[index]);
+            var buildingInfo = PrefabCollection<BuildingInfo>.GetPrefab((uint) fastList.m_buffer[index]);
+            return buildingInfo;
         }
 
         private static void FilterList(Position position, ref FastList<ushort> list)
@@ -139,6 +144,24 @@ namespace BuildingThemes
                 districtIdx, Thread.CurrentThread.ManagedThreadId);
             //District district = Singleton<DistrictManager>.instance.m_districts.m_buffer[districtIdx];
             //TODO(earalov): here fastList variable should be filtered. All buildings that  don't belong to the district should be removed from this list.
+            
+            
+            //this is stub implementation
+            FastList<ushort> newList = new FastList<ushort>();
+            for (int i=0;i<list.m_size;i++)
+            {
+                var name = PrefabCollection<BuildingInfo>.GetPrefab(list.m_buffer[i]).name;
+                if (name.Contains("lock") && districtIdx == 0)
+                {
+                    continue;
+                }
+                if (!name.Contains("lock") && districtIdx != 0)
+                {
+                    continue;
+                }
+                newList.Add(list.m_buffer[i]);
+            }
+            list = newList;
         }
 
 

--- a/BuildingThemes/DetoursHolder.cs
+++ b/BuildingThemes/DetoursHolder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Reflection;
 using ColossalFramework;
@@ -8,26 +9,29 @@ using UnityEngine;
 
 namespace BuildingThemes
 {
- 
+
     class DetoursHolder
     {
 
         //we'll use this variable to pass position to GetRandomBuildingInfo method. Or we can just pass District
         private static Vector3 position;
-        
+
+        public static RedirectCallsState zoneBlockSimulationStepState;
+        public static RedirectCallsState privateBuidingAiSimulationStepState;
+        public static RedirectCallsState privateBuidingAiGetUpgradeInfoState;
+
 
         //this is detoured version of BuildingManger#GetRandomBuildingInfo method. Note, that it's an instance method. It's better because this way all registers will be expected to have the same values
         //as in original methods
         public BuildingInfo GetRandomBuildingInfo(ref Randomizer r, ItemClass.Service service, ItemClass.SubService subService, ItemClass.Level level, int width, int length, BuildingInfo.ZoningMode zoningMode)
         {
-            //Uncomment this to see that this method is really called (floods output_log.txt)
-            //Debug.Log("Building Themes: Detoured GetRandomBuildingInfo was called.");
-            
+            UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo. position: {0}", position);
+
             //this part is the same as in original method
             //I love this hack :) This is how I get this reference - and save it to a variable
-            var buildingManager = (BuildingManager)Convert.ChangeType(this, typeof(BuildingManager));  
-            var refreshAreaBuidlings = typeof(BuildingManager).GetMethod("RefreshAreaBuildings", BindingFlags.NonPublic|BindingFlags.Instance);
-            refreshAreaBuidlings.Invoke(buildingManager, new object[]{});
+            var buildingManager = (BuildingManager)Convert.ChangeType(this, typeof(BuildingManager));
+            var refreshAreaBuidlings = typeof(BuildingManager).GetMethod("RefreshAreaBuildings", BindingFlags.NonPublic | BindingFlags.Instance);
+            refreshAreaBuidlings.Invoke(buildingManager, new object[] { });
             var areaBuildings = (FastList<ushort>[])GetInstanceField(typeof(BuildingManager), buildingManager,
                 "m_areaBuildings");
             var getAreaIndex = typeof(BuildingManager).GetMethod("GetAreaIndex", BindingFlags.NonPublic | BindingFlags.Static);
@@ -37,10 +41,66 @@ namespace BuildingThemes
                 return (BuildingInfo)null;
             if (fastList.m_size == 0)
                 return (BuildingInfo)null;
-           
-            //TODO(earalov): here fastList variable should be filtered. All buildings that  don't belong to district should be removed from tjis list.
+            ushort districtIdx = Singleton<DistrictManager>.instance.GetDistrict(position);
+            UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo. districtIdx: {0}", districtIdx);
+            //District district = Singleton<DistrictManager>.instance.m_districts.m_buffer[districtIdx];
+            //TODO(earalov): here fastList variable should be filtered. All buildings that  don't belong to the district should be removed from this list.
             int index = r.Int32((uint)fastList.m_size);
             return PrefabCollection<BuildingInfo>.GetPrefab((uint)fastList.m_buffer[index]);
+        }
+
+        public void ZoneBlockSimulationStep(ushort blockID)
+        {
+            var zoneBlock = (ZoneBlock)Convert.ChangeType(this, typeof(ZoneBlock));
+            UnityEngine.Debug.LogFormat("Building Themes: Detoured ZoneBlock.SimulationStep was called. blockID: {0}, position: {1}", blockID, zoneBlock.m_position);
+            position = zoneBlock.m_position;
+            var methodInfo = typeof(ZoneBlock).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
+            RedirectionHelper.RevertRedirect(
+                methodInfo,
+                zoneBlockSimulationStepState
+                );
+            methodInfo.Invoke(zoneBlock, new object[] { blockID });
+            RedirectionHelper.RedirectCalls(
+                methodInfo,
+                typeof(DetoursHolder).GetMethod("ZoneBlockSimulationStep", BindingFlags.Public | BindingFlags.Instance)
+                );
+
+        }
+
+        public BuildingInfo PrivateBuildingAiGetUpgradeInfo(ushort buildingID, ref Building data)
+        {
+            UnityEngine.Debug.LogFormat("Building Themes: Detoured PrivateBuildingAI.GetUpgradeInfo was called. buildingID: {0}, position: {1}", buildingID, data.m_position);
+            var privateBuildingAi = (PrivateBuildingAI)Convert.ChangeType(this, typeof(PrivateBuildingAI));
+            position = data.m_position;
+            var methodInfo = typeof(PrivateBuildingAI).GetMethod("GetUpgradeInfo", BindingFlags.Public | BindingFlags.Instance);
+            RedirectionHelper.RevertRedirect(
+                methodInfo,
+                privateBuidingAiGetUpgradeInfoState
+                );
+            var returnValue = (BuildingInfo)methodInfo.Invoke(privateBuildingAi, new object[] { buildingID, data });
+            RedirectionHelper.RedirectCalls(
+                methodInfo,
+                typeof(DetoursHolder).GetMethod("PrivateBuildingAiGetUpgradeInfo", BindingFlags.Public | BindingFlags.Instance)
+                );
+            return returnValue;
+        }
+
+        public void PrivateBuildingAiSimulationStep(ushort buildingID, ref Building buildingData,
+            ref Building.Frame frameData)
+        {
+            UnityEngine.Debug.LogFormat("Building Themes: Detoured PrivateBuildingAI.SimulationStep. buildingID: {0}, position: {1}", buildingID, buildingData.m_position);
+            var privateBuildingAi = (PrivateBuildingAI)Convert.ChangeType(this, typeof(PrivateBuildingAI));
+            position = buildingData.m_position;
+            var methodInfo = typeof(PrivateBuildingAI).GetMethod("SimulationStep", BindingFlags.Public | BindingFlags.Instance);
+            RedirectionHelper.RevertRedirect(
+                methodInfo,
+                privateBuidingAiSimulationStepState
+                );
+            methodInfo.Invoke(privateBuildingAi, new object[] { buildingID, buildingData, frameData });
+            RedirectionHelper.RedirectCalls(
+                methodInfo,
+                typeof(DetoursHolder).GetMethod("PrivateBuildingAiSimulationStep", BindingFlags.Public | BindingFlags.Instance)
+                );
         }
 
         internal static object GetInstanceField(Type type, object instance, string fieldName)

--- a/BuildingThemes/DetoursHolder.cs
+++ b/BuildingThemes/DetoursHolder.cs
@@ -57,6 +57,9 @@ namespace BuildingThemes
         //as in original methods
         public BuildingInfo GetRandomBuildingInfo(ref Randomizer r, ItemClass.Service service, ItemClass.SubService subService, ItemClass.Level level, int width, int length, BuildingInfo.ZoningMode zoningMode)
         {
+
+            var isRandomizerSimulatorManagers = r.seed == Singleton<SimulationManager>.instance.m_randomizer.seed; //I do it here in case if randomizer methodos mell be called later
+            var randimizerSeed = r.seed; //if they are called seed will change
             UnityEngine.Debug.LogFormat("Building Themes: Detoured GetRandomBuildingInfo was called. seed: {0} (singleton seed: {1}). service: {2}, subService: {3}," +
                 "level: {4}, width: {5}, length: {6}, zoningMode: {7}, current thread: {8}\nStack trace: {9}", r.seed, Singleton<SimulationManager>.instance.m_randomizer.seed,
                 service, subService, level, width, length, zoningMode,
@@ -84,7 +87,7 @@ namespace BuildingThemes
                 return (BuildingInfo)null;
             }
 
-            if (r.seed == Singleton<SimulationManager>.instance.m_randomizer.seed)
+            if (isRandomizerSimulatorManagers)
             {
 
                 do
@@ -116,13 +119,13 @@ namespace BuildingThemes
             else
             {
                 UnityEngine.Debug.LogFormat(
-                    "Building Themes: Getting position from seed {0}... current thread: {1}", r.seed, Thread.CurrentThread.ManagedThreadId);
-                var buildingId = seedTable[r.seed];
+                    "Building Themes: Getting position from seed {0}... current thread: {1}", randimizerSeed, Thread.CurrentThread.ManagedThreadId);
+                var buildingId = seedTable[randimizerSeed];
                 var building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingId];
                 var buildingPosition = Position.Build(building.m_position);
                 UnityEngine.Debug.LogFormat(
                         "Building Themes: Getting position from seed {0}. building: {1}, buildingId: {2}, position: {3}, threadId: {4}",
-                        r.seed, building.Info.name, buildingId, buildingPosition.getValue(), 
+                        randimizerSeed, building.Info.name, buildingId, buildingPosition.getValue(), 
                         Thread.CurrentThread.ManagedThreadId);
                 FilterList(buildingPosition, ref fastList);
             }

--- a/BuildingThemes/RedirectionHelper.cs
+++ b/BuildingThemes/RedirectionHelper.cs
@@ -54,6 +54,14 @@ namespace BuildingThemes
             return PatchJumpTo(fptr1, fptr2);
         }
 
+        public static RedirectCallsState RedirectCalls(RuntimeMethodHandle from, RuntimeMethodHandle to)
+        {
+            // GetFunctionPointer enforces compilation of the method.
+            var fptr1 = from.GetFunctionPointer();
+            var fptr2 = to.GetFunctionPointer();
+            return PatchJumpTo(fptr1, fptr2);
+        }
+
         public static void RevertRedirect(MethodInfo from, RedirectCallsState state)
         {
             var fptr1 = from.MethodHandle.GetFunctionPointer();
@@ -66,7 +74,7 @@ namespace BuildingThemes
         /// </summary>
         /// <param name="site"></param>
         /// <param name="target"></param>
-        private static RedirectCallsState PatchJumpTo(IntPtr site, IntPtr target)
+        public static RedirectCallsState PatchJumpTo(IntPtr site, IntPtr target)
         {
             RedirectCallsState state = new RedirectCallsState();
 
@@ -92,7 +100,7 @@ namespace BuildingThemes
             return state;
         }
 
-        private static void RevertJumpTo(IntPtr site, RedirectCallsState state)
+        public static void RevertJumpTo(IntPtr site, RedirectCallsState state)
         {
             unsafe
             {


### PR DESCRIPTION
Have finished methods implementations, but ran into problem. It looks like simple patching won't work for virtual methods and jit-table needs to patched too in order for these 3 methods to be called. 
I will rewrite redirection using [this method from original detours library](https://github.com/sschoener/cities-skylines-detour/blob/master/CitiesSkylinesDebugInformation/RedirectionHelper.cs#L73) my tomorrow. Hopefully it's what we need here.
