### PR TITLE
Destory all instances of building

### DIFF
--- a/BuildingThemes/GUI/ThemeManager/UIBuildingOptions.cs
+++ b/BuildingThemes/GUI/ThemeManager/UIBuildingOptions.cs
@@ -9,6 +9,7 @@ namespace BuildingThemes.GUI
         private UILabel m_noOption;
 
         public UIButton m_plop;
+        public UIButton m_destroy;
 
         private UICheckBox m_include;
         private UITextField m_spawnRate;
@@ -151,6 +152,15 @@ namespace BuildingThemes.GUI
             m_plop.eventClick += (c, p) =>
             {
                 UIThemeManager.instance.Plop(m_item);
+            };
+
+            m_destroy = UIUtils.CreateButton(this);
+            m_destroy.width = 120;
+            m_destroy.text = "Destroy";
+            m_destroy.relativePosition = new Vector3(m_plop.relativePosition.x + m_plop.width + 10f, m_plop.relativePosition.y);
+            m_destroy.eventClick += (c, p) =>
+            {
+                UIThemeManager.instance.DestroyAll(m_item);
             };
 
             // Base Name


### PR DESCRIPTION
Hey,
I sometimes see a very ugly building on the map,
then I go to the theme manager and disable it so that it does not grow again.
The next thing I usually want to do is destroy all instances already grown in my city.
This was a chore so far, sometimes I'd demolish a whole district and let it regrow just to get rid of the ugly buildings inbetween.
I added a button to the Theme Manager to automate the process.
I wanted it to be right of "Plop", but since autolayout is on for the parent UIComponent, it is placed under "Plop". Did not want to mess around with the layout though.
